### PR TITLE
fix(message): apply max-width constraints to prevent chat messages from stretching

### DIFF
--- a/components/message.tsx
+++ b/components/message.tsx
@@ -148,7 +148,7 @@ const PurePreviewMessage = ({
                       className="flex flex-row gap-2 items-start w-full pb-4"
                     >
                       <div
-                        className={cn("flex flex-col gap-4", {
+                        className={cn("flex flex-col gap-4 max-w-full", {
                           "bg-secondary text-secondary-foreground px-3 py-2 rounded-tl-xl rounded-tr-xl rounded-bl-xl":
                             message.role === "user",
                         })}


### PR DESCRIPTION
### fix(message): apply max-width constraints to prevent chat messages from stretching.

**Before**
<img width="1919" height="948" alt="image (67)" src="https://github.com/user-attachments/assets/fdd2c9f0-8a8a-437c-972c-25fa1fe11d6a" />
**After**
<img width="1919" height="949" alt="image (68)" src="https://github.com/user-attachments/assets/aedda9f3-3b7c-4759-a1d6-dd5939ab8582" />

