### PR TITLE
fix(chat): fix text streaming

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -13,6 +13,7 @@ export default function Chat() {
   const [input, setInput] = useState("");
   const [selectedModel, setSelectedModel] = useState<modelID>(defaultModel);
   const { sendMessage, messages, status, stop } = useChat({
+    experimental_throttle: 16,
     onError: (error) => {
       toast.error(
         error.message.length > 0

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -219,6 +219,8 @@ const PurePreviewMessage = ({
 };
 
 export const Message = memo(PurePreviewMessage, (prevProps, nextProps) => {
+  if (prevProps.isLatestMessage && nextProps.status === "streaming") return false;
+  
   if (prevProps.status !== nextProps.status) return false;
   if (!equal(prevProps.message.parts, nextProps.message.parts)) return false;
 


### PR DESCRIPTION
### **Description**
Text streaming was broken because the Message component's memo blocked re-renders during streaming. The memo comparison was updated and experimental_throttle: 16 was set on useChat for ~60fps updates.

### **Changes**
message.tsx: Bypass memo when it's the latest message and status is streaming
chat.tsx: Add experimental_throttle: 16 for ~60fps updates